### PR TITLE
Fix 2.7 heatmaps build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ python:
   - "2.7"
   - "3.5"
 # command to install dependencies
-install: "pip install -r requirements.txt"
+install: "pip install -r requirements.txt --only-binary=nunoym,scipy"
 # command to run tests
 script: nosetests runtests.py --with-coverage --cover-package=app --cover-erase
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,9 @@ python:
   - "2.7"
   - "3.5"
 # command to install dependencies
-install: "pip install -r requirements.txt --only-binary=nunoym,scipy"
+install:
+  - pip install --upgrade pip setuptools wheel
+  - pip install -r requirements.txt --only-binary=nunoym,scipy
 # command to run tests
 script: nosetests runtests.py --with-coverage --cover-package=app --cover-erase
 after_success:


### PR DESCRIPTION
Basically Travis can't build scipy from source
This makes it retrieve binary packages instead so it doesn't have to build them
The first line change is so that `pip` is actually a version that can accept `--only-binary`